### PR TITLE
Update samples to remove usage of "_chart"

### DIFF
--- a/auto_recalls/auto_recalls.malloy
+++ b/auto_recalls/auto_recalls.malloy
@@ -72,6 +72,7 @@ source: recalls is duckdb.table('auto_recalls.csv') extend {
 
   # dashboard
   view: recall_dashboard is by_manufacturer + {
+    # line_chart
     nest: by_year_line_chart is by_year + {group_by: `Recall Type`}
     nest: by_type
     nest: recent_recalls + {limit: 6}

--- a/bigquery/ga_sessions/ga_sessions.malloy
+++ b/bigquery/ga_sessions/ga_sessions.malloy
@@ -18,7 +18,9 @@ source:ga_sessions is bigquery.table('bigquery-public-data.google_analytics_samp
     aggregate: hits_count
     limit: 10
   }
-  view: by_adContent_bar_chart is {
+
+  # bar_chart
+  view: by_adContent is {
     group_by: device.browser
     aggregate: user_count
     group_by: device.deviceCategory
@@ -69,13 +71,14 @@ source:ga_sessions is bigquery.table('bigquery-public-data.google_analytics_samp
 
   view: by_all is {
     nest: by_source
-    nest: by_adContent_bar_chart
+    nest: by_adContent
     nest: by_region
     nest: by_category
   }
 }
 
-query: sessions_dashboard is ga_sessions -> {
+# dashboard
+run: sessions_dashboard is ga_sessions -> {
   nest:
     by_region
     by_device

--- a/bigquery/ga_sessions/ga_sessions.malloy
+++ b/bigquery/ga_sessions/ga_sessions.malloy
@@ -56,6 +56,7 @@ source:ga_sessions is bigquery.table('bigquery-public-data.google_analytics_samp
   view: page_load_times is {
     group_by: hits.page.pageTitle
     aggregate: hit_count is hits.count()
+    # bar_chart
     nest: load_bar_chart is {
       group_by: hit_seconds is floor(hits.latencyTracking.pageLoadTime / 2) * 2
       aggregate: hits_count

--- a/bigquery/ga_sessions/ga_sessions.malloy
+++ b/bigquery/ga_sessions/ga_sessions.malloy
@@ -79,7 +79,7 @@ source:ga_sessions is bigquery.table('bigquery-public-data.google_analytics_samp
 }
 
 # dashboard
-run: sessions_dashboard is ga_sessions -> {
+query: sessions_dashboard is ga_sessions -> {
   nest:
     by_region
     by_device

--- a/bigquery/hackernews/hackernews.malloy
+++ b/bigquery/hackernews/hackernews.malloy
@@ -102,7 +102,8 @@ source: stories is bigquery.table('bigquery-public-data.hacker_news.full') exten
   }
 
   view: term_dashboard is {
-    nest: by_date_and_type_line_chart is {
+    # line_chart
+    nest: by_date_and_type is {
       group_by: posted_month is post_time.month
       aggregate: post_count
       group_by: post_type

--- a/ecommerce/ecommerce.malloy
+++ b/ecommerce/ecommerce.malloy
@@ -182,7 +182,8 @@ source: order_items is order_items_table extend {
     nest: 
       # line_chart
       by_month
-      sales_by_state_shape_map is sales_by_state
+      # shape_map
+      sales_by_state
       top_brands
       top_customers + {aggregate: order_count}
   }

--- a/ecommerce/ecommerce.malloy
+++ b/ecommerce/ecommerce.malloy
@@ -154,7 +154,8 @@ source: order_items is order_items_table extend {
       inventory_items.product.product_count
     nest:
       top_categories
-      by_month_line_chart is by_month
+      # line_chart
+      by_month
       top_products
     limit: 10
   }
@@ -179,7 +180,8 @@ source: order_items is order_items_table extend {
       order_count
       total_gross_margin
     nest: 
-      by_month_line_chart is by_month
+      # line_chart
+      by_month
       sales_by_state_shape_map is sales_by_state
       top_brands
       top_customers + {aggregate: order_count}

--- a/faa/airports.malloy
+++ b/faa/airports.malloy
@@ -19,7 +19,8 @@ source: airports is duckdb.table('../data/airports.parquet') extend {
     group_by: faa_region
     aggregate: airport_count
     nest:
-      by_state_shape_map is by_state
+      # shape_map
+      by_state
       by_facility_type
   }
 }

--- a/faa/flights.malloy
+++ b/faa/flights.malloy
@@ -124,7 +124,8 @@ source: flights is duckdb.table('../data/flights.parquet') extend {
         origin is origin.full_name,
         origin.city
       aggregate: flight_count
-      nest: destinations_by_month_line_chart is {
+      # line_chart
+      nest: destinations_by_month is {
         group_by: dep_month is dep_time.month
         aggregate: flight_count
         group_by: destination.name

--- a/names/names.malloy
+++ b/names/names.malloy
@@ -39,11 +39,13 @@ source: names2 is names extend {
   view: names_chart is {
     group_by: name
     aggregate: births_per_100k
-    nest: by_year_line_chart is {
+    # line_chart
+    nest: by_year is {
       group_by: year_born
       aggregate: population
     }
-    nest: by_state_shape_map is {
+    # shape_mape 
+    nest: by_state is {
       group_by: state
       aggregate: per_100k is population/exclude(population,name)*100000
     }
@@ -74,13 +76,15 @@ source: names2 is names extend {
     limit: 20
   }
 
-  view: gender_year_line_chart is {
+  # line_chart
+  view: gender_year is {
     group_by: year_born
     aggregate: population
     group_by: gender is gender ? pick 'Female' when 'F' else 'Male'
   }
 
-   view: gender_by_state_shape_map is {
+   # shape_map
+   view: gender_by_state is {
       group_by: state
       aggregate: percent_female is population{where: gender='M'}/population
     }
@@ -88,25 +92,26 @@ source: names2 is names extend {
   view: gender_neutral_names is {
     group_by: name
     aggregate: population
-    nest: gender_year_line_chart 
-    nest: gender_by_state_shape_map
+    nest: gender_year
+    nest: gender_by_state
     having: population{where: gender='F'}/population ? > .10 & < .9
     limit: 10
   }
 
+  # dashboard
   view: kelly_time_space_dashboard is {
     where: name = 'Kelly'
     group_by: name
     aggregate: population
-    nest: gender_year_line_chart
-    nest: gender_by_state_shape_map 
+    nest: gender_year
+    nest: gender_by_state
     nest: by_decade is {
       group_by: decade
-      nest: gender_by_state_shape_map
+      nest: gender_by_state
     }
     nest: by_state is {
       group_by: state
-      nest: gender_year_line_chart
+      nest: gender_year
     }
   }
 
@@ -141,26 +146,32 @@ source: names2 is names extend {
     limit: 10
   }
 
+  # dashboard
   view: name_dashboard is {
     where: name = 'Lloyd' | 'Anika' | 'Jessie' | 'Kelly' | 'Todd' | 'Chris'
-    nest: by_name_line_chart is {
+    # line_chart
+    nest: by_name is {
       group_by: decade
       aggregate: births_per_100k
       group_by: name
     }
-    nest: by_name_bar_chart is {
+    # bar_chart
+    nest: by_name_view is {
       group_by: name
       aggregate: births_per_100k
       group_by: gender
     }
-    nest: name_dashboard is {
+    # dashboard
+    nest: name_dash is {
       group_by: name
       aggregate: population
-      nest: by_year_line_chart is {
+      # line_chart
+      nest: by_year is {
         group_by: year_born
         aggregate: population
       }
-      nest: by_state_shape_map is {
+      # shape_map
+      nest: by_state is {
         group_by: state
         aggregate: per_100k is population/cohort.population * 100000
       }


### PR DESCRIPTION
With the release of the new renderer, `_bar_chart` and `_line_chart` don't work anymore. Moving the samples to use explicit tags instead.