### PR TITLE
Fix GitHub Actions auth step to skip when running from forks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,7 @@ jobs:
         with:
           submodules: 'true'
       - name: GCloud auth
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: '${{ secrets.BIGQUERY_KEY }}'


### PR DESCRIPTION
## Problem

The `google-github-actions/auth@v2` action fails when secrets aren't available, which happens for workflows triggered from forks (including Dependabot). The error message is:

```
Error: google-github-actions/auth failed with: the GitHub Action workflow must specify exactly one of "workload_identity_provider" or "credentials_json"! If you are specifying input values via GitHub secrets, ensure the secret is being injected into the environment. By default, secrets are not passed to workflows triggered from forks, including Dependabot.
```

## Solution

Add a condition to skip the auth step when running from a fork. The condition checks if:
- It's not a pull request (i.e., it's a push), OR
- It's a pull request from the same repository (not a fork)

This prevents the workflow from failing when secrets aren't available, while still running authentication for legitimate runs from the main repository.

## Changes

- Added `if` condition to GCloud auth step to skip when running from forks