### PR TITLE
updated paths to be relative to project root

### DIFF
--- a/auto_recalls/auto_recalls.malloy
+++ b/auto_recalls/auto_recalls.malloy
@@ -1,6 +1,6 @@
 // Auto Recalls: CSV example
 ##! m4warnings
-source: recalls is duckdb.table('auto_recalls.csv') extend {
+source: recalls is duckdb.table('auto_recalls/auto_recalls.csv') extend {
   measure:
     recall_count is count()
     percent_of_recalls is recall_count/all(recall_count)*100

--- a/cubed_data/build_cube.malloynb
+++ b/cubed_data/build_cube.malloynb
@@ -17,7 +17,7 @@ COPY (
       count(tail_num) as _plane_count,
       count(*) as _flight_count,
       GROUPING_ID(dep_date, carrier, origin, destination, tail_num) as gid
-    FROM '../data/flights.parquet'
+    FROM 'data/flights.parquet'
     GROUP BY cube (dep_date, carrier, origin, destination, tail_num)
   )
   SELECT 
@@ -32,7 +32,7 @@ COPY (
   FROM cube_table
 ) to 'flights_cubed.parquet' (FORMAT 'parquet', CODEC 'ZSTD')
 >>>malloy
-source: flights_cubed is duckdb.table('./flights_cubed.parquet') extend {
+source: flights_cubed is duckdb.table('cubed_data/flights_cubed.parquet') extend {
     measure: row_count is count()
 }
 >>>malloy

--- a/cubed_data/flights_cube.malloy
+++ b/cubed_data/flights_cube.malloy
@@ -1,6 +1,6 @@
 ##! experimental{composite_sources}
 
-source: flights_cubed is duckdb.table('flights_cubed.parquet')
+source: flights_cubed is duckdb.table('cubed_data/flights_cubed.parquet')
 
 source: `cube:` is flights_cubed extend { where: agg_level = '' except: `origin`,`dep_date`,`destination`,`carrier`,`tail_num` }
 source: `cube:carrier` is flights_cubed extend { where: agg_level = 'carrier' except: `dep_date`,`tail_num`,`destination`,`origin` }

--- a/ecommerce/ecommerce.malloy
+++ b/ecommerce/ecommerce.malloy
@@ -1,8 +1,8 @@
 // duckdb sources
-source: users_table is duckdb.table('../data/users.parquet') extend {}
-source: product_table is duckdb.table('../data/products.parquet') extend {}
-source: inventory_items_table is duckdb.table('../data/inventory_items.parquet') extend {}
-source: order_items_table is duckdb.table('../data/order_items.parquet')
+source: users_table is duckdb.table('data/users.parquet') extend {}
+source: product_table is duckdb.table('data/products.parquet') extend {}
+source: inventory_items_table is duckdb.table('data/inventory_items.parquet') extend {}
+source: order_items_table is duckdb.table('data/order_items.parquet')
 
 
 source: users is users_table extend {

--- a/ecommerce/nested_subtotals.malloynb
+++ b/ecommerce/nested_subtotals.malloynb
@@ -35,8 +35,8 @@ WITH sales_by_department AS (
         b.product_department
         , sum(case when date_trunc('year', a.created_at) = '2021-01-01' then a.sale_price else 0 end) as sales_2021
         , sum(case when date_trunc('year', a.created_at) = '2022-01-01' then a.sale_price else 0 end) as sales_2022
-    FROM read_parquet('../data/order_items.parquet') a
-    LEFT JOIN read_parquet('../data/inventory_items.parquet') b on a.inventory_item_id = b.id
+    FROM read_parquet('data/order_items.parquet') a
+    LEFT JOIN read_parquet('data/inventory_items.parquet') b on a.inventory_item_id = b.id
     GROUP BY 1
 )
 SELECT
@@ -60,8 +60,8 @@ WITH sales_by_department_and_category AS (
         , b.product_category
         , sum(case when date_trunc('year', a.created_at) = '2021-01-01' then a.sale_price else 0 end) as sales_2021
         , sum(case when date_trunc('year', a.created_at) = '2022-01-01' then a.sale_price else 0 end) as sales_2022
-    FROM read_parquet('../data/order_items.parquet') a
-    LEFT JOIN read_parquet('../data/inventory_items.parquet') b on a.inventory_item_id = b.id
+    FROM read_parquet('data/order_items.parquet') a
+    LEFT JOIN read_parquet('data/inventory_items.parquet') b on a.inventory_item_id = b.id
     group by 1,2
 )
 SELECT

--- a/faa/airports.malloy
+++ b/faa/airports.malloy
@@ -1,4 +1,4 @@
-source: airports is duckdb.table('../data/airports.parquet') extend {
+source: airports is duckdb.table('data/airports.parquet') extend {
   rename: facility_type is fac_type
 
   measure: airport_count is count()

--- a/faa/flights.malloy
+++ b/faa/flights.malloy
@@ -1,26 +1,26 @@
-source: carriers is duckdb.table('../data/carriers.parquet') extend {
+source: carriers is duckdb.table('data/carriers.parquet') extend {
   primary_key: code
   measure: carrier_count is count()
 }
 
-source: airports is duckdb.table('../data/airports.parquet') extend {
+source: airports is duckdb.table('data/airports.parquet') extend {
   primary_key: code
   measure: airport_count is count()
   dimension: name is concat(code, '-', full_name )
 }
 
-source: aircraft_models is duckdb.table('../data/aircraft_models.parquet') extend {
+source: aircraft_models is duckdb.table('data/aircraft_models.parquet') extend {
   primary_key: aircraft_model_code
   measure: aircraft_model_count is count()
 }
 
-source: aircraft is duckdb.table('../data/aircraft.parquet') extend {
+source: aircraft is duckdb.table('data/aircraft.parquet') extend {
   primary_key: tail_num
   measure: aircraft_count is count()
   join_one: aircraft_models with aircraft_model_code
 }
 
-source: flights is duckdb.table('../data/flights.parquet') extend {
+source: flights is duckdb.table('data/flights.parquet') extend {
   primary_key: id2
 
   // rename some fields as from their physical names

--- a/ga4/ga4.malloy
+++ b/ga4/ga4.malloy
@@ -3,7 +3,7 @@ source: events is duckdb.sql("""
   SELECT
     *,
     (event_timestamp / 1000)::bigint as event_timestamp_ms
-  FROM 'ga4_events_sampled.snappy.parquet'
+  FROM 'ga4/ga4_events_sampled.snappy.parquet'
   """) extend {
   rename:
     event_timestamp_raw is event_timestamp

--- a/imdb/build_titles.malloysql
+++ b/imdb/build_titles.malloysql
@@ -12,7 +12,6 @@ This script produces three files.  Files are downloaded from https://datasets.im
 * names.parquet - information about the people that worked on the movies.
 
 This script is designed to run locally (not from the web version).  Clone the repository and launch VSCode
-
 >>>markdown
 ## Raw Data Definitions
 Define sources for all the raw data.
@@ -30,7 +29,7 @@ source: raw_titles is duckdb.sql("""
 		SELECT * FROM
 		read_csv_auto(
 			-- 'https://datasets.imdbws.com/title.basics.tsv.gz'
-			'data/title.basics.tsv.gz'
+			'imdb/data/title.basics.tsv.gz'
 			, all_varchar=true, delim='\t', quote='',header=True)
 	""")
 
@@ -38,7 +37,7 @@ source: raw_principals is duckdb.sql("""
 		SELECT * FROM
 		read_csv_auto(
 			-- 'https://datasets.imdbws.com/title.principals.tsv.gz'
-			'data/title.principals.tsv.gz'
+			'imdb/data/title.principals.tsv.gz'
 			, all_varchar=true, delim='\t', quote='',header=True)
 	""")
 
@@ -46,7 +45,7 @@ source: raw_ratings is duckdb.sql("""
 		SELECT * FROM
 		read_csv_auto(
 			-- 'https://datasets.imdbws.com/title.ratings.tsv.gz'
-			'data/title.ratings.tsv.gz'
+			'imdb/data/title.ratings.tsv.gz'
 			, all_varchar=true, delim='\t', quote='',header=True)
 	""")
 
@@ -54,14 +53,14 @@ source: raw_crew is duckdb.sql("""
 		SELECT * FROM
 		read_csv_auto(
 			-- 'https://datasets.imdbws.com/title.crew.tsv.gz'
-			'data/title.crew.tsv.gz'
+			'imdb/data/title.crew.tsv.gz'
 			, all_varchar=true, delim='\t', quote='',header=True)
 	""")
 source: raw_names is duckdb.sql(""" 
 		SELECT * FROM
 		read_csv_auto(
 			-- 'https://datasets.imdbws.com/name.basics.tsv.gz'
-			'data/name.basics.tsv.gz'
+			'imdb/data/name.basics.tsv.gz'
 			, all_varchar=true, delim='\t', quote='',header=True)
 	""")
 >>>markdown
@@ -96,7 +95,6 @@ copy %{
     }
 }%  to 'data/titles.parquet' (FORMAT 'parquet', CODEC 'ZSTD')
 
-
 >>>markdown
 ## Build principals.parquet
 
@@ -121,7 +119,6 @@ copy
     }
   }%
  to 'principals.parquet' (FORMAT 'parquet', CODEC 'ZSTD')
-
 
 
 >>>markdown

--- a/imdb/harvard-cs050.malloynb
+++ b/imdb/harvard-cs050.malloynb
@@ -4,11 +4,11 @@ Harvard's beginnning computer science class teaches a section on SQL.  The class
 
 Below is the semantic data model used to answer all the questions
 >>>malloy
-source: people is duckdb.table('data/names.parquet')
-source: principals is duckdb.table('data/principals.parquet') extend {
+source: people is duckdb.table('imdb/data/names.parquet')
+source: principals is duckdb.table('imdb/data/principals.parquet') extend {
   join_one: people is people on nconst = people.nconst
 }
-source: movies is duckdb.table('data/titles.parquet') extend {
+source: movies is duckdb.table('imdb/data/titles.parquet') extend {
   join_many: principals on tconst = principals.tconst
   join_many: principals2 is principals on tconst = principals2.tconst
   measure:

--- a/imdb/imdb.malloy
+++ b/imdb/imdb.malloy
@@ -5,23 +5,23 @@
 //  Github: https://github.com/lloydtabb/imdb_fiddle
 //  About Fiddles: https://github.com/lloydtabb/malloy_fiddle_dist/
 
-source: people is duckdb.table('data/names.parquet') extend {
+source: people is duckdb.table('imdb/data/names.parquet') extend {
 // cast, crew, everyone involved in movies
   primary_key: nconst
 }
 
-source: principals is duckdb.table('data/principals.parquet') extend {
+source: principals is duckdb.table('imdb/data/principals.parquet') extend {
 // a mapping table that links people to movies, along with their job on that movie.
   join_one: people is people on nconst = people.nconst
 }
 
-query: genre_movie_map is duckdb.table('data/titles.parquet') -> {
+query: genre_movie_map is duckdb.table('imdb/data/titles.parquet') -> {
   group_by:
     tconst
     genre is genres.value
 }
 
-source: movies is duckdb.table('data/titles.parquet') extend {
+source: movies is duckdb.table('imdb/data/titles.parquet') extend {
 // all the movies
   join_many: principals on tconst = principals.tconst
   join_many: principals2 is principals on tconst = principals2.tconst

--- a/names/names.malloy
+++ b/names/names.malloy
@@ -1,4 +1,4 @@
-source: names is duckdb.table('usa_names.parquet') extend {
+source: names is duckdb.table('names/usa_names.parquet') extend {
   rename: year_born is `year`
   measure: population is `number`.sum()
   dimension: decade is floor(year_born/10)*10

--- a/names/names1.malloynb
+++ b/names/names1.malloynb
@@ -13,7 +13,7 @@ The dataset is a single table with 5 columns:
 ## The semantic data model
 In order to analyze this data, we're going to rename a couple of columns and build some reusable calculations.  `total_population` is a measure and can be used in an `aggregate:` calculation.  Decade is computed from year, and can be used in a `group_by:` or `select:`.  Click on 'Schema' to see the data that is provided.
 >>>malloy
-source: names is duckdb.table('usa_names.parquet') extend {
+source: names is duckdb.table('names/usa_names.parquet') extend {
   rename: year_born is `year`   // 'year' is a reserved keyword in Malloy
   rename: population is `number`  // 'number' is a reserved keyword in Malloy
 

--- a/names/names2.malloynb
+++ b/names/names2.malloynb
@@ -4,7 +4,7 @@ We can add 'views' to our semantic model that are reusable. As we've seen earlie
 
 Clicking 'Run Query' above the view will run the query for you and show you the results.
 >>>malloy
-source: names2 is duckdb.table('usa_names.parquet') extend {
+source: names2 is duckdb.table('names/usa_names.parquet') extend {
   rename: year_born is `year`   // 'year' is a malloy reserved word
   rename: population is `number`  // 'number' is a malloy reserve word.
 

--- a/patterns/autobin.malloynb
+++ b/patterns/autobin.malloynb
@@ -2,7 +2,7 @@
 # Automatically Binning Data
 By examining the range of values over a dataset, we can compute the appropriate histogram bin size, while capturing the data at the same time.  We can then pipe the output to another query to display a histogram.
 >>>malloy
-source: airports is duckdb.table('../data/airports.parquet') extend {
+source: airports is duckdb.table('data/airports.parquet') extend {
   measure: airport_count is count()
   # bar_chart
   view: by_elevation is {

--- a/patterns/cohorts.malloynb
+++ b/patterns/cohorts.malloynb
@@ -4,8 +4,8 @@ It is often useful to see how groups of people behave over time.  The most simpl
 
 We'll use the following model
 >>>malloy
-source: order_items is duckdb.table('../data/order_items.parquet') extend {
-  join_one: users is duckdb.table('../data/users.parquet') on user_id=users.id
+source: order_items is duckdb.table('data/order_items.parquet') extend {
+  join_one: users is duckdb.table('data/users.parquet') on user_id=users.id
   measure: 
     user_count is count(user_id)
     order_count is count()
@@ -63,3 +63,4 @@ run: order_items -> {
   }
 }
 >>>markdown
+

--- a/patterns/dim_index.malloynb
+++ b/patterns/dim_index.malloynb
@@ -15,7 +15,7 @@ Indexing could be used by LLMs to find the interesting column/term mapping in th
 We're going to take the airports table and index it.  The results are an un ordered list of distinct *fieldName/fieldValue* pairs appear in the table.  The weight, in this case is the number of rows that partciular occurs on. 
 >>>malloy
 #(docs) size=medium limit=100
-run: duckdb.table('../data/airports.parquet') -> {
+run: duckdb.table('data/airports.parquet') -> {
   index: *
 }
 >>>markdown
@@ -26,7 +26,7 @@ Adding a second query stage to filter on _string_ columns and ordering by weight
 All Malloy queries run as a single SQL query.  The `index:` operator is no different.  Click the **SQL** tab to see how this works.  
 >>>malloy
 #(docs) size=medium limit=100
-run: duckdb.table('../data/airports.parquet') -> {
+run: duckdb.table('data/airports.parquet') -> {
   index: *
 } -> {
   where: fieldType = 'string'
@@ -40,7 +40,7 @@ run: duckdb.table('../data/airports.parquet') -> {
 Indexes can be used find the best way to filter a dataset.  For example supposed we'd like to find 'SANTA CRUZ' in the dataset. Upon approaching the dataset, but we don't which column might contain it.  In a UI you might imagine that you type 'SANTA' and let have suggestons for values that might be appropriate.  In the results we can see that top value, 'SANTA ROSA', appears as county on 26 rows in the table.  We can also see that 'SANTA CRUZ' is both a `city` and a `county`..
 >>>malloy
 #(docs) size=medium limit=100
-run: duckdb.table('../data/airports.parquet') -> {
+run: duckdb.table('data/airports.parquet') -> {
   index: *
 } -> {
   where: fieldValue ~ r'SANTA'
@@ -53,7 +53,7 @@ run: duckdb.table('../data/airports.parquet') -> {
 We can then write a simple query to show the rows.  It turns out that 'SANTA CRUZ' is a county in both California and Arizona.
 >>>malloy
 #(docs) size=medium limit=100
-run: duckdb.table('../data/airports.parquet') -> {
+run: duckdb.table('data/airports.parquet') -> {
   where: county ~ 'SANTA CRUZ'
   select: *
 }
@@ -63,7 +63,7 @@ run: duckdb.table('../data/airports.parquet') -> {
 It is often difficult to approach a new dataset.  The index operator provides an intersting way to quickly gain an understanding of the dataset.  By piping the results of an index another stage, we can quickly see all the interesting values for each of the interesting dimesions.  Again, the weight shows the number of rows for that particular dimension/value.
 >>>malloy
 #(docs) size=medium limit=100
-run: duckdb.table('../data/airports.parquet') -> {
+run: duckdb.table('data/airports.parquet') -> {
   index: *
 } -> {
   group_by: fieldName
@@ -80,7 +80,7 @@ run: duckdb.table('../data/airports.parquet') -> {
 With large datasets, you can also sample a small subsection using the `sample:` parameter.  Sampled indexes are great at identifing the important low cardinality fields.
 >>>malloy
 #(docs) size=medium limit=100
-run: duckdb.table('../data/airports.parquet') -> {
+run: duckdb.table('data/airports.parquet') -> {
   index: *
   sample: 5000  // sample only 5000 rows
 } -> {
@@ -102,9 +102,9 @@ The rest of this pages uses the model below.  The data is an excerpt from the IM
 
 We use the measure `total_ratings` to determin a movie's popularity.  An individual's popularity is determined by the some of all the ratings of the movies a person has worked on.
 >>>malloy
-source: movies is duckdb.table('../imdb/data/titles.parquet') extend {
-  join_many: principals is duckdb.table('../imdb/data/principals.parquet') extend {
-    join_one: people is duckdb.table('../imdb/data/names.parquet') 
+source: movies is duckdb.table('imdb/data/titles.parquet') extend {
+  join_many: principals is duckdb.table('imdb/data/principals.parquet') extend {
+    join_one: people is duckdb.table('imdb/data/names.parquet') 
       on nconst = people.nconst
   } on tconst = principals.tconst
   measure: total_ratings is numVotes.sum()
@@ -144,9 +144,9 @@ run: movies -> {
 
 By convention indexes in sources are named `search_index`.
 >>>malloy
-source: movies2 is duckdb.table('../imdb/data/titles.parquet') extend {
-  join_many: principals is duckdb.table('../imdb/data/principals.parquet') extend {
-    join_one: people is duckdb.table('../imdb/data/names.parquet') 
+source: movies2 is duckdb.table('imdb/data/titles.parquet') extend {
+  join_many: principals is duckdb.table('imdb/data/principals.parquet') extend {
+    join_one: people is duckdb.table('imdb/data/names.parquet') 
       on nconst = people.nconst
   } on tconst = principals.tconst
 
@@ -183,3 +183,4 @@ run: movies2 -> search_index -> {
   order_by: weight desc
 }
 >>>markdown
+

--- a/patterns/foreign_sums.malloynb
+++ b/patterns/foreign_sums.malloynb
@@ -3,16 +3,16 @@
 Malloy allows you to compute sums and averages correctly based on your join tree. Fan-outs based on join relationships will never impact the correctness of these aggregations. This example has `flights`, joining to `aircraft`, joining to `aircraft_model`.
 `aircraft_model` has the number of seats specified on this model of aircraft.  Code below computes sums and averages at various places in the join tree.
 >>>malloy
-source: aircraft_models is duckdb.table('../data/aircraft_models.parquet') extend {
+source: aircraft_models is duckdb.table('data/aircraft_models.parquet') extend {
   primary_key: aircraft_model_code
 }
 
-source: aircraft is duckdb.table('../data/aircraft.parquet') extend {
+source: aircraft is duckdb.table('data/aircraft.parquet') extend {
   primary_key: tail_num
   join_one: aircraft_models with aircraft_model_code
 }
 
-source: flights is duckdb.table('../data/flights.parquet') extend {
+source: flights is duckdb.table('data/flights.parquet') extend {
   join_one: aircraft with tail_num
 }
 >>>malloy
@@ -35,3 +35,4 @@ run: flights -> {
     average_seats_per_model is aircraft.aircraft_models.seats.avg()
 }
 >>>markdown
+

--- a/patterns/moving_avg.malloynb
+++ b/patterns/moving_avg.malloynb
@@ -5,7 +5,7 @@ Malloy can compute moving averages on resultsets.
 
 The queries below use the following model
 >>>malloy
-source: order_items is duckdb.table('../data/order_items.parquet') extend {
+source: order_items is duckdb.table('data/order_items.parquet') extend {
   measure: 
     user_count is count(user_id)
     order_count is count()
@@ -49,7 +49,7 @@ run: order_items -> {
 
 In this example, we've added two queries to the `flights` source, one showing flights by month without the moving average applied, and one with the moving average applied. We then use these queries to show charts of flight count for each airport over time.
 >>>malloy
-source: flights is duckdb.table('../data/flights.parquet') extend {
+source: flights is duckdb.table('data/flights.parquet') extend {
   measure: flight_count is count()
   dimension: dep_month is dep_time.month
 
@@ -77,3 +77,4 @@ run: flights -> {
   nest: moving_averaged
 }
 >>>markdown
+

--- a/patterns/nested_subtotals.malloynb
+++ b/patterns/nested_subtotals.malloynb
@@ -5,7 +5,7 @@ Nested subtotals are quite painful to do in SQL, requiring either self-joins, wi
 
 To see how we do this in Malloy, let's look at the following simple model:
 >>>malloy
-source: order_items is duckdb.table('../data/order_items.parquet') extend {
+source: order_items is duckdb.table('data/order_items.parquet') extend {
   primary_key: id
 
   measure:

--- a/patterns/other.malloynb
+++ b/patterns/other.malloynb
@@ -5,7 +5,7 @@ Often you want to limit the number of group-by values in a table, and bucket eve
 
 In the `top_states_by_eleveation` query below, we have a query with two stages. The first stage calculates the top states and nests the data to be aggregated. The second pipeline stage produces the actual aggregation.
 >>>malloy
-source: airports is duckdb.table('../data/airports.parquet') extend {
+source: airports is duckdb.table('data/airports.parquet') extend {
   measure: 
     airport_count is count()
     avg_elevation is elevation.avg()
@@ -45,3 +45,4 @@ run: airports -> {
   nest: top_states_by_elevation
 }
 >>>markdown
+

--- a/patterns/percent_of_total.malloynb
+++ b/patterns/percent_of_total.malloynb
@@ -2,8 +2,8 @@
 # Percent of Total
 Malloy provides a way to compute _percent of total_ through level of detail (ungrouped aggregates) functions.  The functions `all()` and `exclude()` escape grouping in aggregate calculations.  These functions are different than window functions as they operate inline with the query and can produce correct results even when the data hits a `limit` or is fanned out.  Use cases below.
 >>>malloy
-source: flights is duckdb.table('../data/flights.parquet') extend {
-  join_one: carriers is duckdb.table('../data/carriers.parquet') on carrier = carriers.code
+source: flights is duckdb.table('data/flights.parquet') extend {
+  join_one: carriers is duckdb.table('data/carriers.parquet') on carrier = carriers.code
   measure: flight_count is count()
 }
 >>>markdown
@@ -74,3 +74,4 @@ run: flights -> {
     `carriers as a percentage of route` is flight_count / exclude(flight_count, nickname)
 }
 >>>markdown
+

--- a/patterns/reading_nested.malloynb
+++ b/patterns/reading_nested.malloynb
@@ -17,7 +17,7 @@ To perform aggregate calculations in Malloy, you can simply specify the complete
 
 Here is a very simple Malloy model describing some interesting calculations on Google Analytics data:
 >>>malloy
-source: ga_sessions is duckdb.table('../data/ga_sample.parquet') extend {
+source: ga_sessions is duckdb.table('data/ga_sample.parquet') extend {
   measure:
     user_count is count(fullVisitorId)
     # percent
@@ -89,3 +89,4 @@ run: ga_sessions -> {
   }
 }
 >>>markdown
+

--- a/patterns/sessionize.malloynb
+++ b/patterns/sessionize.malloynb
@@ -2,10 +2,9 @@
 # Sessionized Data - Map/Reduce
 
 Flight event data contains _dep_time_, _carrier_, _origin_, _destination_ and _tail_num_  (the plane that made the flight).  The query below takes the flight event data and maps it into sessions of _flight_date_, _carrier_, and _tail_num_.  For each session, a nested list of _flight_legs_ by the aircraft on that day.  The flight legs are numbered.
-
 >>>malloy
 #(docs) size=large limit=5000
-run: duckdb.table('../data/flights.parquet') extend {
+run: duckdb.table('data/flights.parquet') extend {
   where: carrier = 'WN' and dep_time ? @2002-03-03
   measure: flight_count is count()
 } -> {
@@ -31,3 +30,4 @@ run: duckdb.table('../data/flights.parquet') extend {
   } 
 }
 >>>markdown
+

--- a/patterns/unnest_data.malloynb
+++ b/patterns/unnest_data.malloynb
@@ -10,7 +10,7 @@ source: airports is duckdb.sql("""
   SELECT 
     *,
     SPLIT(city,' ') as city_words
-  FROM '../data/airports.parquet' 
+  FROM 'data/airports.parquet' 
 """) extend {
   measure:
     airport_count is count()
@@ -31,7 +31,7 @@ run: airports -> {
 ## Cross Joining an array
 Sometimes it is useful to join in an array of numbers.  Example below joins in some number
 >>>malloy
-source: flights is duckdb.table('../data/flights.parquet') extend {
+source: flights is duckdb.table('data/flights.parquet') extend {
   measure: flight_count is count()
 }
 
@@ -48,5 +48,5 @@ run: flights -> {
     total is flight_count
   order_by: num
   where:
-    arr_delay != null and dep_delay != null
+    arr_delay is not null and dep_delay is not null
 }

--- a/patterns/yoy.malloynb
+++ b/patterns/yoy.malloynb
@@ -7,7 +7,7 @@ There are a couple of different ways to go about this in Malloy.
 We can compare performance of different years using the same x and y-axes.  Line charts take the x-axis, y-axis and dimensional (color) axis as parameters.
 In this case, the x-axis is `month_of_year`, the y-axis is `flight_count` and the dimensional (color) axis is the year.
 >>>malloy
-source: flights is duckdb.table('../data/flights.parquet') extend {
+source: flights is duckdb.table('data/flights.parquet') extend {
   measure: flight_count is count()
 }
 >>>malloy
@@ -61,9 +61,9 @@ run: flights -> {
 ## Bonus: Relative timeframes and expression reuse
 You might like to write queries that automatically adjust based on the current timeframe.  The query below uses date arithmetic to filter the data to time frames relative to now.  These measures probably aren't generally useful in the model so we use the `extend:` operation to add these measure so they are only locally accessable within the query.
 >>>malloy
-source: inventory_items is duckdb.table('../data/inventory_items.parquet') 
+source: inventory_items is duckdb.table('data/inventory_items.parquet') 
 
-source: order_items is duckdb.table('../data/order_items.parquet') extend {
+source: order_items is duckdb.table('data/order_items.parquet') extend {
   join_one: inventory_items  on inventory_item_id = inventory_items.id
   measure: order_item_count is count()
 
@@ -86,3 +86,4 @@ source: order_items is duckdb.table('../data/order_items.parquet') extend {
 
 run: order_items -> category_growth
 >>>markdown
+


### PR DESCRIPTION
## Summary
- Reapplies the changes from #103 (by @mrtimo) which were blocked by a DCO failure on the original branch.
- Updates path references across sample `.malloy` / `.malloynb` / `.malloysql` files so they are relative to the project root rather than to the file referencing the data (the new convention for this repo).
- Carries one unrelated but valid Malloy syntax fix in `patterns/unnest_data.malloynb`: `!= null` → `is not null`.

Closes #103.